### PR TITLE
Ignore unicode errors

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -372,6 +372,9 @@ class bot_connect(irc.bot.SingleServerIRCBot):
             self.connection.quit("Exiting.")
             print "Quit IRC."
         except Exception, e:
+            # add better exception handling and stacktrace
+            print "%s: %s" % (e.__class__.__name__, e.args)
+            traceback.print_exc()
             self.connection.quit("%s: %s" % (e.__class__.__name__, e.args))
         raise
 

--- a/core/bot.py
+++ b/core/bot.py
@@ -364,6 +364,8 @@ class bot_connect(irc.bot.SingleServerIRCBot):
         self.channel = '#' + channel
         self.nickname = nickname
         self.realname = realname
+        # set 'errors' to replace unicode decode failures with '?'
+        self.connection.buffer_class.errors = 'replace'
         try:
             self.start()
         except KeyboardInterrupt:


### PR DESCRIPTION
https://github.com/apalos/tatianna/commit/d897ee1f2193e03d1702c114ad90ad5f801a05d1
Changes decoder error handling from strict to replace, therefore
replacing any bytes that failed to decode with "?".
This previously raised a:
  `UnicodeDecodeError: 'utf8' codec can't decode byte 0xc2 in position 509: unexpected end of data`
and complained about message size being bigger than 512.
This may not be the best fix for this, it might be better to just
strip out the bytes that we can't decode, as usually it will be
the last bytes where a multi-byte unicode has been chipped, but
doing that could lead to scenarios where messages are getting
clipped and might be much harder to debug.

https://github.com/apalos/tatianna/commit/21bc983b4402898d9db556f24d345ebf01403f5c
Adds better exception reporting by printing the exception class
and a full stacktrace when an exception is raised
